### PR TITLE
Fix typo in base name

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 grade: devel
 confinement: devmode
 
-base: core19
+base: core18
 
 layout:
   /usr/bin/fontpreview:


### PR DESCRIPTION
`base: core19` isn't a valid base.  I think this was probably a typo for `base: core18`.